### PR TITLE
Renaming master to main

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -3,10 +3,10 @@ name: Linting
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 jobs:
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -3,10 +3,10 @@ name: Testing
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 jobs:
   testing:
     strategy:


### PR DESCRIPTION
The default branch was renamed from master to main so updating the CI files to point to the new branch.